### PR TITLE
Truning off the rule for enforcing naming convention

### DIFF
--- a/configs/formatting-relaxed.js
+++ b/configs/formatting-relaxed.js
@@ -5,7 +5,6 @@
  */
 
 /* eslint-env node */
-/* eslint-disable @typescript-eslint/naming-convention */
 
 const OFF = 'off';
 const WARN = 'warn';

--- a/configs/formatting.js
+++ b/configs/formatting.js
@@ -5,7 +5,6 @@
  */
 
 /* eslint-env node */
-/* eslint-disable @typescript-eslint/naming-convention */
 
 const OFF = 'off';
 const ERROR = 'error';
@@ -21,7 +20,7 @@ module.exports = Object.freeze({
          * https://typescript-eslint.io/rules/naming-convention
          */
         '@typescript-eslint/naming-convention': [
-          ERROR,
+          OFF,
           {
             selector: 'default',
             format: ['strictCamelCase']
@@ -87,7 +86,7 @@ module.exports = Object.freeze({
      * https://typescript-eslint.io/rules/naming-convention
      */
     '@typescript-eslint/naming-convention': [
-      ERROR,
+      OFF,
       {
         selector: 'default',
         format: ['strictCamelCase']

--- a/configs/ts-for-js-relaxed.js
+++ b/configs/ts-for-js-relaxed.js
@@ -5,7 +5,6 @@
  */
 
 /* eslint-env node */
-/* eslint-disable @typescript-eslint/naming-convention */
 
 const OFF = 'off';
 const WARN = 'warn';

--- a/configs/ts-for-js.js
+++ b/configs/ts-for-js.js
@@ -5,7 +5,6 @@
  */
 
 /* eslint-env node */
-/* eslint-disable @typescript-eslint/naming-convention */
 
 const OFF = 'off';
 const ERROR = 'error';

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,6 @@
  */
 
 /* eslint-env node */
-/* eslint-disable @typescript-eslint/naming-convention */
 
 module.exports = {
   // All imported modules in your tests should be mocked automatically

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jm/eslint-config-ts-for-js",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "An ESLint configuration for linting JavaScript with typescript-eslint",
   "exports": {
     ".": "./configs/ts-for-js.js",

--- a/tests/configs/__snapshots__/combined-relaxed.test.js.snap
+++ b/tests/configs/__snapshots__/combined-relaxed.test.js.snap
@@ -255,7 +255,7 @@ exports[`ts-for-js config plus formatting 1`] = `
       "off",
     ],
     "@typescript-eslint/naming-convention": [
-      "error",
+      "off",
       {
         "format": [
           "strictCamelCase",

--- a/tests/configs/__snapshots__/combined.test.js.snap
+++ b/tests/configs/__snapshots__/combined.test.js.snap
@@ -255,7 +255,7 @@ exports[`ts-for-js config plus formatting 1`] = `
       "off",
     ],
     "@typescript-eslint/naming-convention": [
-      "error",
+      "off",
       {
         "format": [
           "strictCamelCase",

--- a/tests/configs/__snapshots__/formatting.test.js.snap
+++ b/tests/configs/__snapshots__/formatting.test.js.snap
@@ -9,7 +9,7 @@ exports[`formatting should match the snapshot 1`] = `
       ],
       "rules": {
         "@typescript-eslint/naming-convention": [
-          "error",
+          "off",
           {
             "format": [
               "strictCamelCase",
@@ -103,7 +103,7 @@ exports[`formatting should match the snapshot 1`] = `
     "@typescript-eslint/member-ordering": "off",
     "@typescript-eslint/method-signature-style": "off",
     "@typescript-eslint/naming-convention": [
-      "error",
+      "off",
       {
         "format": [
           "strictCamelCase",

--- a/tests/configs/combined-relaxed.test.js
+++ b/tests/configs/combined-relaxed.test.js
@@ -1,6 +1,5 @@
 /* eslint-env jest */
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const { ESLint } = require('eslint');
 
 test('ts-for-js config plus formatting', async () => {

--- a/tests/configs/combined.test.js
+++ b/tests/configs/combined.test.js
@@ -1,6 +1,5 @@
 /* eslint-env jest */
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const { ESLint } = require('eslint');
 
 test('ts-for-js config plus formatting', async () => {


### PR DESCRIPTION
This rule is not helpful when using third party modules